### PR TITLE
Publicized builder constructor

### DIFF
--- a/src/main/java/net/jodah/expiringmap/ExpiringMap.java
+++ b/src/main/java/net/jodah/expiringmap/ExpiringMap.java
@@ -119,7 +119,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
     /**
      * Creates a new Builder object.
      */
-    private Builder() {
+    public Builder() {
     }
 
     /**
@@ -510,9 +510,12 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
 
   /**
    * Creates an ExpiringMap builder.
-   * 
+   *
    * @return New ExpiringMap builder
+   *
+   * @deprecated New programs should use {@link Builder()}.
    */
+  @Deprecated
   public static Builder<Object, Object> builder() {
     return new Builder<Object, Object>();
   }


### PR DESCRIPTION
Resolves #13 

This commit solves a problem with vague generic types of created `Builder` objects. It promotes using the default `Builder` constructor instead of a static creator method.