### PR TITLE
Added Ticker for testing with custom time

### DIFF
--- a/src/main/java/net/jodah/expiringmap/ExpiringMap.java
+++ b/src/main/java/net/jodah/expiringmap/ExpiringMap.java
@@ -684,6 +684,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
 
   @Override
   public boolean containsValue(Object value) {
+    expireEntries();
     readLock.lock();
     try {
       return entries.containsValue(value);
@@ -710,6 +711,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
 
       @Override
       public Iterator<Map.Entry<K, V>> iterator() {
+        expireEntries();
         return (entries instanceof EntryLinkedHashMap) ? ((EntryLinkedHashMap<K, V>) entries).new EntryIterator()
             : ((EntryTreeHashMap<K, V>) entries).new EntryIterator();
       }
@@ -834,6 +836,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
 
   @Override
   public int hashCode() {
+    expireEntries();
     readLock.lock();
     try {
       return entries.hashCode();
@@ -868,6 +871,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
 
       @Override
       public Iterator<K> iterator() {
+        expireEntries();
         return (entries instanceof EntryLinkedHashMap) ? ((EntryLinkedHashMap<K, V>) entries).new KeyIterator()
             : ((EntryTreeHashMap<K, V>) entries).new KeyIterator();
       }
@@ -952,6 +956,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
     Assert.notNull(key, "key");
     writeLock.lock();
     try {
+      expireEntriesInternal();
       if (!entries.containsKey(key))
         return putInternal(key, value, expirationPolicy.get(), expirationNanos.get());
       else
@@ -982,6 +987,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
     Assert.notNull(key, "key");
     writeLock.lock();
     try {
+      expireEntriesInternal();
       ExpiringEntry<K, V> entry = entries.get(key);
       if (entry != null && entry.getValue().equals(value)) {
         entries.remove(key);
@@ -1000,6 +1006,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
     Assert.notNull(key, "key");
     writeLock.lock();
     try {
+      expireEntriesInternal();
       if (entries.containsKey(key)) {
         return putInternal(key, value, expirationPolicy.get(), expirationNanos.get());
       } else
@@ -1014,6 +1021,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
     Assert.notNull(key, "key");
     writeLock.lock();
     try {
+      expireEntriesInternal();
       ExpiringEntry<K, V> entry = entries.get(key);
       if (entry != null && entry.getValue().equals(oldValue)) {
         putInternal(key, newValue, expirationPolicy.get(), expirationNanos.get());
@@ -1086,6 +1094,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
     Assert.operation(variableExpiration, "Variable expiration is not enabled");
     writeLock.lock();
     try {
+      expireEntriesInternal();
       ExpiringEntry<K, V> entry = entries.get(key);
       if (entry != null) {
         entry.expirationNanos.set(TimeUnit.NANOSECONDS.convert(duration, timeUnit));
@@ -1140,6 +1149,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
 
   @Override
   public int size() {
+    expireEntries();
     readLock.lock();
     try {
       return entries.size();
@@ -1150,6 +1160,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
 
   @Override
   public String toString() {
+    expireEntries();
     readLock.lock();
     try {
       return entries.toString();
@@ -1173,6 +1184,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
 
       @Override
       public Iterator<V> iterator() {
+        expireEntries();
         return (entries instanceof EntryLinkedHashMap) ? ((EntryLinkedHashMap<K, V>) entries).new ValueIterator()
             : ((EntryTreeHashMap<K, V>) entries).new ValueIterator();
       }
@@ -1237,6 +1249,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
   V putInternal(K key, V value, ExpirationPolicy expirationPolicy, long expirationNanos) {
     writeLock.lock();
     try {
+      expireEntriesInternal();
       ExpiringEntry<K, V> entry = entries.get(key);
       V oldValue = null;
 

--- a/src/main/java/net/jodah/expiringmap/Ticker.java
+++ b/src/main/java/net/jodah/expiringmap/Ticker.java
@@ -1,0 +1,28 @@
+package net.jodah.expiringmap;
+
+/**
+ * Time source. Provides a time value representing nanoseconds elapsed since some arbitrary point in time.
+ */
+public abstract class Ticker {
+    private static final Ticker SYSTEM_TICKER = new Ticker() {
+        @Override
+        public long time() {
+            return System.nanoTime();
+        }
+    };
+
+    /**
+     * A ticker that reads the current time using {@link System#nanoTime()}
+     */
+    public static Ticker systemTicker() { return SYSTEM_TICKER; }
+
+    /**
+     * Constructor to be used by subclasses
+     */
+    protected Ticker() {}
+
+    /**
+     * Returns number of nanoseconds since this ticker's point of reference
+     */
+    public abstract long time();
+}

--- a/src/test/java/net/jodah/expiringmap/CustomValueTicker.java
+++ b/src/test/java/net/jodah/expiringmap/CustomValueTicker.java
@@ -1,0 +1,21 @@
+package net.jodah.expiringmap;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Modifiable custom value ticker.
+ * Returns set time value as current time after conversion from ms.
+ * Starts with time equal to 0.
+ */
+public class CustomValueTicker extends Ticker {
+  private long value = 0;
+
+  public void setValue(long valueInMs) {
+    this.value = TimeUnit.MILLISECONDS.toNanos(valueInMs);
+  }
+
+  @Override
+  public long time() {
+    return value;
+  }
+}

--- a/src/test/java/net/jodah/expiringmap/ExpiringEntryTest.java
+++ b/src/test/java/net/jodah/expiringmap/ExpiringEntryTest.java
@@ -24,7 +24,7 @@ public class ExpiringEntryTest {
   public void testEntryOrdering() {
     AtomicReference<ExpirationPolicy> expirationPolicy = new AtomicReference<ExpirationPolicy>(ExpirationPolicy.CREATED);
     NavigableSet<ExpiringEntry<String, String>> set = new TreeSet<ExpiringEntry<String, String>>();
-    Ticker ticker = new FixedTicker();
+    Ticker ticker = new CustomValueTicker();
     ExpiringEntry<String, String> entry1 = new ExpiringEntry<String, String>("a", "a", expirationPolicy,
       new AtomicLong(1000000), ticker);
     ExpiringEntry<String, String> entry2 = new ExpiringEntry<String, String>("b", "b", expirationPolicy,
@@ -54,7 +54,7 @@ public class ExpiringEntryTest {
   public void testEntryReplaceSameKey() {
     AtomicReference<ExpirationPolicy> expirationPolicy = new AtomicReference<ExpirationPolicy>(ExpirationPolicy.CREATED);
     Set<ExpiringEntry<String, String>> set = new TreeSet<ExpiringEntry<String, String>>();
-    Ticker ticker = new FixedTicker();
+    Ticker ticker = new CustomValueTicker();
     ExpiringEntry<String, String> entry1 = new ExpiringEntry<String, String>("a", "a", expirationPolicy,
       new AtomicLong(1000), ticker);
     ExpiringEntry<String, String> entry2 = new ExpiringEntry<String, String>("a", "a", expirationPolicy,
@@ -65,11 +65,4 @@ public class ExpiringEntryTest {
     assertFalse(set.add(entry2));
     assertFalse(set.add(entry3));
   }
-
-  private static class FixedTicker extends Ticker {
-    @Override
-    public long time() {
-      return 0;
-    }
-  };
 }

--- a/src/test/java/net/jodah/expiringmap/ExpiringEntryTest.java
+++ b/src/test/java/net/jodah/expiringmap/ExpiringEntryTest.java
@@ -24,16 +24,17 @@ public class ExpiringEntryTest {
   public void testEntryOrdering() {
     AtomicReference<ExpirationPolicy> expirationPolicy = new AtomicReference<ExpirationPolicy>(ExpirationPolicy.CREATED);
     NavigableSet<ExpiringEntry<String, String>> set = new TreeSet<ExpiringEntry<String, String>>();
+    Ticker ticker = new FixedTicker();
     ExpiringEntry<String, String> entry1 = new ExpiringEntry<String, String>("a", "a", expirationPolicy,
-      new AtomicLong(1000000));
+      new AtomicLong(1000000), ticker);
     ExpiringEntry<String, String> entry2 = new ExpiringEntry<String, String>("b", "b", expirationPolicy,
-      new AtomicLong(1000000));
+      new AtomicLong(1000000), ticker);
     ExpiringEntry<String, String> entry3 = new ExpiringEntry<String, String>("c", "c", expirationPolicy,
-      new AtomicLong(1000000));
+      new AtomicLong(1000000), ticker);
     ExpiringEntry<String, String> entry4 = new ExpiringEntry<String, String>("e", "e", expirationPolicy,
-      new AtomicLong(5000));
+      new AtomicLong(5000), ticker);
     ExpiringEntry<String, String> entry5 = new ExpiringEntry<String, String>("f", "f", expirationPolicy,
-      new AtomicLong(1100000));
+      new AtomicLong(1100000), ticker);
     set.add(entry1);
     set.add(entry2);
     set.add(entry3);
@@ -53,14 +54,22 @@ public class ExpiringEntryTest {
   public void testEntryReplaceSameKey() {
     AtomicReference<ExpirationPolicy> expirationPolicy = new AtomicReference<ExpirationPolicy>(ExpirationPolicy.CREATED);
     Set<ExpiringEntry<String, String>> set = new TreeSet<ExpiringEntry<String, String>>();
+    Ticker ticker = new FixedTicker();
     ExpiringEntry<String, String> entry1 = new ExpiringEntry<String, String>("a", "a", expirationPolicy,
-      new AtomicLong(1000));
+      new AtomicLong(1000), ticker);
     ExpiringEntry<String, String> entry2 = new ExpiringEntry<String, String>("a", "a", expirationPolicy,
-      new AtomicLong(1000));
+      new AtomicLong(1000), ticker);
     ExpiringEntry<String, String> entry3 = new ExpiringEntry<String, String>("a", "a", expirationPolicy,
-      new AtomicLong(1500));
+      new AtomicLong(1500), ticker);
     set.add(entry1);
     assertFalse(set.add(entry2));
     assertFalse(set.add(entry3));
   }
+
+  private static class FixedTicker extends Ticker {
+    @Override
+    public long time() {
+      return 0;
+    }
+  };
 }

--- a/src/test/java/net/jodah/expiringmap/ExpiringMapTest.java
+++ b/src/test/java/net/jodah/expiringmap/ExpiringMapTest.java
@@ -1,14 +1,26 @@
 package net.jodah.expiringmap;
 
-import java.util.*;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertEqualsNoOrder;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Tests {@link ExpiringMap}.

--- a/src/test/java/net/jodah/expiringmap/functional/ExpirationListenerTest.java
+++ b/src/test/java/net/jodah/expiringmap/functional/ExpirationListenerTest.java
@@ -1,15 +1,13 @@
 package net.jodah.expiringmap.functional;
 
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
+import net.jodah.concurrentunit.Waiter;
 import net.jodah.expiringmap.CustomValueTicker;
-import net.jodah.expiringmap.internal.Assert;
+import net.jodah.expiringmap.ExpiringMap;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import net.jodah.concurrentunit.Waiter;
-import net.jodah.expiringmap.ExpiringMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertTrue;
 

--- a/src/test/java/net/jodah/expiringmap/functional/ExpirationListenerTest.java
+++ b/src/test/java/net/jodah/expiringmap/functional/ExpirationListenerTest.java
@@ -3,11 +3,15 @@ package net.jodah.expiringmap.functional;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import net.jodah.expiringmap.CustomValueTicker;
+import net.jodah.expiringmap.internal.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import net.jodah.concurrentunit.Waiter;
 import net.jodah.expiringmap.ExpiringMap;
+
+import static org.testng.Assert.assertTrue;
 
 @Test
 public class ExpirationListenerTest {
@@ -40,6 +44,33 @@ public class ExpirationListenerTest {
   }
 
   /**
+   * Tests that an expiration listener is called as expected.
+   * Custom ticker without sleeping needs some additional call to force expiration.
+   */
+  public void shouldCallExpirationListenerWithCustomTicker() throws Throwable {
+    final String key = "a";
+    final String value = "v";
+
+    CustomValueTicker ticker = new CustomValueTicker();
+    Map<String, String> map = ExpiringMap.builder()
+        .expiration(100, TimeUnit.MILLISECONDS)
+        .expirationListener((thekey, thevalue) -> {
+          waiter.assertEquals(key, thekey);
+          waiter.assertEquals(value, thevalue);
+          waiter.resume();
+        })
+        .ticker(ticker)
+        .build();
+
+    map.put(key, value);
+
+    ticker.setValue(150);
+    assertTrue(map.isEmpty());
+
+    waiter.await(10);
+  }
+
+  /**
    * Tests that an async expiration listener is called as expected.
    */
   public void shouldCallAsyncExpirationListener() throws Throwable {
@@ -58,5 +89,31 @@ public class ExpirationListenerTest {
     map.put(key, value);
 
     waiter.await(5000);
+  }
+
+  /**
+   * Tests that an async expiration listener is called as expected.
+   */
+  public void shouldCallAsyncExpirationListenerWithCustomTicker() throws Throwable {
+    final String key = "a";
+    final String value = "v";
+
+    CustomValueTicker ticker = new CustomValueTicker();
+    Map<String, String> map = ExpiringMap.builder()
+        .expiration(100, TimeUnit.MILLISECONDS)
+        .expirationListener((thekey, thevalue) -> {
+          waiter.assertEquals(key, thekey);
+          waiter.assertEquals(value, thevalue);
+          waiter.resume();
+        })
+        .ticker(ticker)
+        .build();
+
+    map.put(key, value);
+
+    ticker.setValue(150);
+    assertTrue(map.isEmpty());
+
+    waiter.await(10);
   }
 }

--- a/src/test/java/net/jodah/expiringmap/functional/ExpirationTest.java
+++ b/src/test/java/net/jodah/expiringmap/functional/ExpirationTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import net.jodah.expiringmap.CustomValueTicker;
 import org.testng.annotations.Test;
 
 import net.jodah.expiringmap.ExpiringMap;
@@ -21,12 +22,13 @@ public class ExpirationTest {
    */
   public void shouldExpireEntries() throws Exception {
     // Given
-    ExpiringMap<String, String> map = ExpiringMap.builder().expiration(100, TimeUnit.MILLISECONDS).build();
+    CustomValueTicker ticker = new CustomValueTicker();
+    ExpiringMap<String, String> map = ExpiringMap.builder().expiration(100, TimeUnit.MILLISECONDS).ticker(ticker).build();
 
     // When
     for (int i = 0; i < 100; i++)
       map.put("John" + i, "Joe");
-    Thread.sleep(150);
+    ticker.setValue(150);
 
     // Then
     assertTrue(map.isEmpty());
@@ -39,21 +41,22 @@ public class ExpirationTest {
    */
   public void shouldExpireEntriesInOrder() throws Exception {
     // Given
-    Map<String, String> map = ExpiringMap.builder().expiration(100, TimeUnit.MILLISECONDS).build();
+    CustomValueTicker ticker = new CustomValueTicker();
+    Map<String, String> map = ExpiringMap.builder().expiration(100, TimeUnit.MILLISECONDS).ticker(ticker).build();
 
     // When
     map.put("John", "Doe");
-    Thread.sleep(50);
+    ticker.setValue(50);
     assertTrue(map.containsKey("John"));
     map.put("Moe", "Doe");
-    Thread.sleep(70);
+    ticker.setValue(120);
     assertFalse(map.containsKey("John"));
     assertTrue(map.containsKey("Moe"));
     map.put("Joe", "Doe");
-    Thread.sleep(50);
+    ticker.setValue(170);
     assertFalse(map.containsKey("Moe"));
     assertTrue(map.containsKey("Joe"));
-    Thread.sleep(60);
+    ticker.setValue(230);
 
     // Then
     assertTrue(map.isEmpty());
@@ -62,15 +65,36 @@ public class ExpirationTest {
   public void testPutShouldNotRescheduleWithCreatedPolicy() throws Throwable {
     final AtomicBoolean expired = new AtomicBoolean();
     ExpiringMap<String, String> map = ExpiringMap.builder()
-        .expiration(180, TimeUnit.MILLISECONDS)
-        .expirationListener((k, v) -> expired.set(true))
-        .build();
+            .expiration(180, TimeUnit.MILLISECONDS)
+            .expirationListener((k, v) -> expired.set(true))
+            .build();
 
     map.put("test", "test");
     Thread.sleep(100);
     map.put("test", "test");
     assertFalse(expired.get());
     Thread.sleep(100);
+
+    assertTrue(expired.get());
+  }
+
+  public void testPutShouldNotRescheduleWithCreatedPolicyWithCustomTicker() throws Throwable {
+    final AtomicBoolean expired = new AtomicBoolean();
+    CustomValueTicker ticker = new CustomValueTicker();
+    ExpiringMap<String, String> map = ExpiringMap.builder()
+            .expiration(180, TimeUnit.MILLISECONDS)
+            .expirationListener((k, v) -> expired.set(true))
+            .ticker(ticker)
+            .build();
+
+    map.put("test", "test");
+    ticker.setValue(100);
+    map.put("test", "test");
+    assertFalse(expired.get());
+    ticker.setValue(200);
+
+    //only to push map to check expiration
+    assertTrue(map.isEmpty());
 
     assertTrue(expired.get());
   }


### PR DESCRIPTION
Ticker class was added for providing custom time values. This is mostly useful during testing, as with using custom time provider you don't need to base on Thread.sleep, and also tests can be performed much faster. Default ticker provider uses System.nanoTime. 
Still adding this functionality required to enforce expiration checking with most of the map methods in addition to executor scheduling. To ensure correctness additional test cases were added.

Base code remain compatible with Java 6, so Java 8 java.time.Clock class could not be used.