### PR TITLE
Add expirationType to ExpirationListener

### DIFF
--- a/src/main/java/net/jodah/expiringmap/ExpirationListener.java
+++ b/src/main/java/net/jodah/expiringmap/ExpirationListener.java
@@ -13,5 +13,5 @@ public interface ExpirationListener<K, V> {
    * @param key Expired key
    * @param value Expired value
    */
-  void expired(K key, V value);
+  void expired(K key, V value, ExpirationType type);
 }

--- a/src/main/java/net/jodah/expiringmap/ExpirationType.java
+++ b/src/main/java/net/jodah/expiringmap/ExpirationType.java
@@ -1,0 +1,6 @@
+package net.jodah.expiringmap;
+
+public enum ExpirationType {
+	TIME,
+	SIZE
+}

--- a/src/test/java/net/jodah/expiringmap/ExpiringMapTest.java
+++ b/src/test/java/net/jodah/expiringmap/ExpiringMapTest.java
@@ -37,9 +37,9 @@ public class ExpiringMapTest {
   public void testAddAndGetAsyncExpirationListener() {
     // Given
     ExpiringMap<String, String> map = ExpiringMap.create();
-    ExpirationListener<String, String> listener1 = (k, v) -> {
+    ExpirationListener<String, String> listener1 = (k, v, type) -> {
     };
-    ExpirationListener<String, String> listener2 = (k, v) -> {
+    ExpirationListener<String, String> listener2 = (k, v, type) -> {
     };
 
     // When
@@ -57,9 +57,9 @@ public class ExpiringMapTest {
   public void testAddExpirationListener() {
     // Given
     ExpiringMap<String, String> map = ExpiringMap.create();
-    ExpirationListener<String, String> listener1 = (k, v) -> {
+    ExpirationListener<String, String> listener1 = (k, v, type) -> {
     };
-    ExpirationListener<String, String> listener2 = (k, v) -> {
+    ExpirationListener<String, String> listener2 = (k, v, type) -> {
     };
 
     // When
@@ -69,6 +69,22 @@ public class ExpiringMapTest {
     // Then
     assertEquals(listener1, map.expirationListeners.get(0));
     assertEquals(listener2, map.expirationListeners.get(1));
+  }
+  
+  /**
+   * Tests {@link ExpiringMap#addExpirationListener(ExpirationListener)}.
+   */
+  public void testExpirationType() {
+    // Given
+    ExpiringMap<String, String> map = ExpiringMap.builder().maxSize(1).build();
+    ExpirationListener<String, String> listener1 = (k, v, type) -> {
+    	assertEquals(type, ExpirationType.SIZE);
+    	assertEquals(k, "a");
+    };
+    map.addExpirationListener(listener1);
+    
+    map.put("a", "a");
+    map.put("b", "b");
   }
 
   /**
@@ -263,9 +279,9 @@ public class ExpiringMapTest {
   public void testRemoveAsyncExpirationListener() {
     // Given
     ExpiringMap<String, String> map = ExpiringMap.create();
-    ExpirationListener<String, String> listener1 = (k, v) -> {
+    ExpirationListener<String, String> listener1 = (k, v, type) -> {
     };
-    ExpirationListener<String, String> listener2 = (k, v) -> {
+    ExpirationListener<String, String> listener2 = (k, v, type) -> {
     };
 
     // When
@@ -286,9 +302,9 @@ public class ExpiringMapTest {
   public void testRemoveExpirationListener() {
     // Given
     ExpiringMap<String, String> map = ExpiringMap.create();
-    ExpirationListener<String, String> listener1 = (k, v) -> {
+    ExpirationListener<String, String> listener1 = (k, v, type) -> {
     };
-    ExpirationListener<String, String> listener2 = (k, v) -> {
+    ExpirationListener<String, String> listener2 = (k, v, type) -> {
     };
 
     // When

--- a/src/test/java/net/jodah/expiringmap/functional/DeadlockTest.java
+++ b/src/test/java/net/jodah/expiringmap/functional/DeadlockTest.java
@@ -30,7 +30,7 @@ public class DeadlockTest {
 
     final ExpiringMap<String, Long> map = ExpiringMap.builder()
         .expiration(duration, TimeUnit.MILLISECONDS)
-        .expirationListener((key, value) -> {
+        .expirationListener((key, value, type) -> {
           if (key.equals(finalKey))
             waiter.resume();
         })

--- a/src/test/java/net/jodah/expiringmap/functional/ExpirationAccuracyTest.java
+++ b/src/test/java/net/jodah/expiringmap/functional/ExpirationAccuracyTest.java
@@ -42,7 +42,7 @@ public class ExpirationAccuracyTest extends ConcurrentTestCase {
   private void putTest(final int threadCount, final int mapCount, final long duration) throws Throwable {
     final String finalKey = "final";
 
-    ExpirationListener<String, Long> expirationListener = (key, startTime) -> {
+    ExpirationListener<String, Long> expirationListener = (key, startTime, type) -> {
       // Assert that expiration is within 1/10 second of expected time
       threadAssertTrue(System.currentTimeMillis() - (startTime + duration) < 100);
       if (key.equals(finalKey))

--- a/src/test/java/net/jodah/expiringmap/functional/ExpirationListenerTest.java
+++ b/src/test/java/net/jodah/expiringmap/functional/ExpirationListenerTest.java
@@ -27,7 +27,7 @@ public class ExpirationListenerTest {
 
     Map<String, String> map = ExpiringMap.builder()
         .expiration(100, TimeUnit.MILLISECONDS)
-        .expirationListener((thekey, thevalue) -> {
+        .expirationListener((thekey, thevalue, type) -> {
           waiter.assertEquals(key, thekey);
           waiter.assertEquals(value, thevalue);
           waiter.resume();
@@ -48,7 +48,7 @@ public class ExpirationListenerTest {
 
     Map<String, String> map = ExpiringMap.builder()
         .expiration(100, TimeUnit.MILLISECONDS)
-        .expirationListener((thekey, thevalue) -> {
+        .expirationListener((thekey, thevalue, type) -> {
           waiter.assertEquals(key, thekey);
           waiter.assertEquals(value, thevalue);
           waiter.resume();

--- a/src/test/java/net/jodah/expiringmap/functional/ExpirationTest.java
+++ b/src/test/java/net/jodah/expiringmap/functional/ExpirationTest.java
@@ -63,7 +63,7 @@ public class ExpirationTest {
     final AtomicBoolean expired = new AtomicBoolean();
     ExpiringMap<String, String> map = ExpiringMap.builder()
         .expiration(180, TimeUnit.MILLISECONDS)
-        .expirationListener((k, v) -> expired.set(true))
+        .expirationListener((k, v, type) -> expired.set(true))
         .build();
 
     map.put("test", "test");


### PR DESCRIPTION
As I mentioned in this [issue,](https://github.com/jhalterman/expiringmap/issues/51) sometimes it is required to know why expiration is performed. ExpirationListener.expired() method is called due to two reasons. The first one is time based expiration for an entry and the second one is when entry size > maxSize. I just added expiration type to ExpirationListener.