### PR TITLE
Allow shutdown of executors, to clean up resources.

### DIFF
--- a/src/main/java/net/jodah/expiringmap/ExpiringMap.java
+++ b/src/main/java/net/jodah/expiringmap/ExpiringMap.java
@@ -1382,4 +1382,15 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
       }
     };
   }
+
+  public synchronized static void shutdown() {
+    if (EXPIRER != null) {
+      EXPIRER.shutdown();
+      EXPIRER = null;
+    }
+    if (LISTENER_SERVICE != null) {
+      LISTENER_SERVICE.shutdown();
+      LISTENER_SERVICE = null;
+    }
+  }
 }


### PR DESCRIPTION
Proper cleanup of resource, avoid problems e.g. on Tomcat undeploy, which currently generates:

```
org.apache.catalina.loader.WebappClassLoaderBase.clearReferencesThreads The web application [w2s] appears to have started a thread named [ExpiringMap-Expirer] but has failed to stop it. This is very likely to create a memory leak.
```

In this way it has to be called manually, but it's more generic.
Another approach could be to auto-register a context listener to automatically shutdown, like logback is doing or using a `@WebListener` annotation.