### PR TITLE
Fixed expiringEntryLoader example documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Lazily loaded entries can also be made to expire at varying times:
 
 ```java
 Map<String, Connection> connections = ExpiringMap.builder()
-  .expiringEntry(address -> new ExpiringValue(new Connection(address), 5, TimeUnit.MINUTES))
+  .expiringEntryLoader((ExpiringEntryLoader<String, Connection>) address -> new ExpiringValue(new Connection(address), 5, TimeUnit.MINUTES))
   .build();
 ```
 


### PR DESCRIPTION
The sample documentation on lazy, variable expiration entry loading is not correct. Fixed the right method and added object types to the lambda. Without those, the type of `address` cannot be inferred, and `new Connection(String)` will complain that it cannot cast from `Object` to `String`.