### PR TITLE
java 12 crash fix on tests phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.2.201409121644</version>
+        <version>0.8.4</version>
         <executions>
           <execution>
             <id>prepare-agent</id>


### PR DESCRIPTION
On java 12:

> [INFO] -------------------------------------------------------
> [INFO]  T E S T S
> [INFO] -------------------------------------------------------
> [WARNING] Corrupted STDOUT by directly writing to native stream in forked JVM 1. See FAQ web page and the dump file C:\Users\tbw777\Downloads\expiringmap-master3\expiringmap\target\surefire-reports\2019-06-12T00-06-29_066-jvmRun1.dumpstream
> [INFO] 
> [INFO] Results:
> [INFO] 
> [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
> [INFO] 
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD FAILURE
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time: 4.674 s
> [INFO] Finished at: 2019-06-12T00:06:30+03:00
> [INFO] Final Memory: 20M/88M
> [INFO] ------------------------------------------------------------------------
> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project expiringmap: There are test failures.
> [ERROR] 
> [ERROR] Please refer to C:\Users\tbw777\Downloads\expiringmap-master3\expiringmap\target\surefire-reports for the individual test results.
> [ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
> [ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
> [ERROR] Command was cmd.exe /X /C ""C:\Program Files\Java\jdk-12\bin\java" -javaagent:C:\\Users\\tbw777\\.m2\\repository\\org\\jacoco\\org.jacoco.agent\\0.7.2.201409121644\\org.jacoco.agent-0.7.2.201409121644-runtime.jar=destfile=C:\\Users\\tbw777\\Downloads\\expiringmap-master3\\expiringmap\\target\\jacoco.exec -jar C:\Users\tbw777\AppData\Local\Temp\surefire17846198944393361262\surefirebooter17078388566794502538.jar C:\Users\tbw777\AppData\Local\Temp\surefire17846198944393361262 2019-06-12T00-06-29_066-jvmRun1 surefire6623251754680498928tmp surefire_011819205746905992530tmp"
> [ERROR] Error occurred in starting fork, check output in log
> [ERROR] Process Exit Code: 1
> [ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
> [ERROR] Command was cmd.exe /X /C ""C:\Program Files\Java\jdk-12\bin\java" -javaagent:C:\\Users\\tbw777\\.m2\\repository\\org\\jacoco\\org.jacoco.agent\\0.7.2.201409121644\\org.jacoco.agent-0.7.2.201409121644-runtime.jar=destfile=C:\\Users\\tbw777\\Downloads\\expiringmap-master3\\expiringmap\\target\\jacoco.exec -jar C:\Users\tbw777\AppData\Local\Temp\surefire17846198944393361262\surefirebooter17078388566794502538.jar C:\Users\tbw777\AppData\Local\Temp\surefire17846198944393361262 2019-06-12T00-06-29_066-jvmRun1 surefire6623251754680498928tmp surefire_011819205746905992530tmp"
> [ERROR] Error occurred in starting fork, check output in log
> [ERROR] Process Exit Code: 1
> [ERROR] at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:670)
> [ERROR] at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:283)
> [ERROR] at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:246)
> [ERROR] at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1161)
> [ERROR] at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1002)
> [ERROR] at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:848)
> [ERROR] at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
> [ERROR] at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
> [ERROR] at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
> [ERROR] at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
> [ERROR] at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
> [ERROR] at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
> [ERROR] at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
> [ERROR] at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
> [ERROR] at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
> [ERROR] at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
> [ERROR] at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
> [ERROR] at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
> [ERROR] at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
> [ERROR] at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
> [ERROR] at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> [ERROR] at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
> [ERROR] at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> [ERROR] at java.base/java.lang.reflect.Method.invoke(Method.java:567)
> [ERROR] at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
> [ERROR] at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
> [ERROR] at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
> [ERROR] at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
> [ERROR] at org.codehaus.classworlds.Launcher.main(Launcher.java:47)
> [ERROR] -> [Help 1]
> [ERROR] 
> [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
> [ERROR] Re-run Maven using the -X switch to enable full debug logging.
> [ERROR] 
> [ERROR] For more information about the errors and possible solutions, please read the following articles:
> [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
> 
> Process finished with exit code 1
> 

Changing jacoco-maven-plugin version has fix this problem