### PR TITLE
Iterating of the map should not throw a ConcurrentModificationException

### DIFF
--- a/src/test/java/net/jodah/expiringmap/ExpiringMapTest.java
+++ b/src/test/java/net/jodah/expiringmap/ExpiringMapTest.java
@@ -441,10 +441,11 @@ public class ExpiringMapTest {
   /**
    * Asserts that concurrent modification throws an exception.
    */
-  @Test(expectedExceptions = ConcurrentModificationException.class)
-  public void testValuesThrowsOnConcurrentModification() {
+  @Test
+  public void testValuesNotThrowsOnConcurrentModification() {
     ExpiringMap<String, String> map = ExpiringMap.create();
     map.put("a", "a");
+    map.put("b", "b");
 
     Iterator<String> valuesIterator = map.values().iterator();
     valuesIterator.next();

--- a/src/test/java/net/jodah/expiringmap/issues/Issue10.java
+++ b/src/test/java/net/jodah/expiringmap/issues/Issue10.java
@@ -1,0 +1,58 @@
+package net.jodah.expiringmap.issues;
+
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Do not throw ConcurrentModificationException when using an Iterator
+ */
+@Test
+public class Issue10 {
+    public void testEntrySet() {
+        Map<Integer, Integer> map = ExpiringMap.builder().expiration(30, TimeUnit.SECONDS).expirationPolicy(ExpirationPolicy.ACCESSED).build();
+        map.put(1, 1);
+        map.put(2, 2);
+        Iterator<Map.Entry<Integer, Integer>> iterator = map.entrySet().iterator();
+        Assert.assertEquals((Integer) 1, iterator.next().getKey());
+        map.put(3, 3);
+        Assert.assertEquals((Integer) 2, iterator.next().getKey());
+        // we don't require the iterator to be updated with the new '3' entry and we neither expect a ConcurrentModificationException
+        if (iterator.hasNext()) {
+            Assert.assertEquals((Integer) 3, iterator.next().getKey());
+        }
+    }
+
+    public void testValues() {
+        Map<Integer, Integer> map = ExpiringMap.builder().expiration(30, TimeUnit.SECONDS).expirationPolicy(ExpirationPolicy.ACCESSED).build();
+        map.put(1, 1);
+        map.put(2, 2);
+        Iterator<Integer> iterator = map.values().iterator();
+        Assert.assertEquals((Integer) 1, iterator.next());
+        map.put(3, 3);
+        Assert.assertEquals((Integer) 2, iterator.next());
+        // we don't require the iterator to be updated with the new '3' entry and we neither expect a ConcurrentModificationException
+        if (iterator.hasNext()) {
+            Assert.assertEquals((Integer) 3, iterator.next());
+        }
+    }
+
+    public void testKeySet() {
+        Map<Integer, Integer> map = ExpiringMap.builder().expiration(30, TimeUnit.SECONDS).expirationPolicy(ExpirationPolicy.ACCESSED).build();
+        map.put(1, 1);
+        map.put(2, 2);
+        Iterator<Integer> iterator = map.keySet().iterator();
+        Assert.assertEquals((Integer) 1, iterator.next());
+        map.put(3, 3);
+        Assert.assertEquals((Integer) 2, iterator.next());
+        // we don't require the iterator to be updated with the new '3' entry and we neither expect a ConcurrentModificationException
+        if (iterator.hasNext()) {
+            Assert.assertEquals((Integer) 3, iterator.next());
+        }
+    }
+}


### PR DESCRIPTION
Create a copy of the entries (guarded by a readLock) and iterate over that copy.
This fixes #10 and maybe #30 (needs further testing though, couldn't reproduce that)

Create a copy of the underlying map and iterate over that, never throwing a ConcurrentModificationException. This comes with a small performance penalty though (copying the map content to new instance) but fixing the exception should have priority as this violates the contract of this class (threadsafe)