### PR TITLE
Use the readLock when creating an Iterator for the Map.

### DIFF
--- a/src/main/java/net/jodah/expiringmap/ExpiringMap.java
+++ b/src/main/java/net/jodah/expiringmap/ExpiringMap.java
@@ -714,8 +714,13 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
 
       @Override
       public Iterator<Map.Entry<K, V>> iterator() {
-        return (entries instanceof EntryLinkedHashMap) ? ((EntryLinkedHashMap<K, V>) entries).new EntryIterator()
-            : ((EntryTreeHashMap<K, V>) entries).new EntryIterator();
+        readLock.lock();
+        try {
+          return (entries instanceof EntryLinkedHashMap) ? ((EntryLinkedHashMap<K, V>) entries).new EntryIterator()
+                  : ((EntryTreeHashMap<K, V>) entries).new EntryIterator();
+        } finally {
+          readLock.unlock();
+        }
       }
 
       @Override


### PR DESCRIPTION
This is an addition to the fix implemented with #78 which did not cover all cases.