### PR TITLE
Fix #93: handle very long expirations without blocking others

### DIFF
--- a/src/main/java/net/jodah/expiringmap/ExpiringMap.java
+++ b/src/main/java/net/jodah/expiringmap/ExpiringMap.java
@@ -78,6 +78,7 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
   static volatile ScheduledExecutorService EXPIRER;
   static volatile ThreadPoolExecutor LISTENER_SERVICE;
   static ThreadFactory THREAD_FACTORY;
+  private static final long NO_EXPIRATION = Long.MAX_VALUE;
 
   List<ExpirationListener<K, V>> expirationListeners;
   List<ExpirationListener<K, V>> asyncExpirationListeners;
@@ -598,7 +599,8 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
 
     /** Resets the entry's expected expiration. */
     void resetExpiration() {
-      expectedExpiration.set(expirationNanos.get() + System.nanoTime());
+      long duration = expirationNanos.get();
+      expectedExpiration.set(duration == NO_EXPIRATION ? NO_EXPIRATION : safeAdd(System.nanoTime(), duration));
     }
 
     /** Marks the entry as scheduled. */
@@ -611,6 +613,13 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
     synchronized void setValue(V value) {
       this.value = value;
     }
+  }
+
+  private static long safeAdd(long base, long delta) {
+    long result = base + delta;
+    if (((base ^ result) & (delta ^ result)) < 0)
+      return Long.MAX_VALUE;
+    return result;
   }
 
   /**
@@ -1355,6 +1364,10 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
       if (entry.scheduled)
         return;
 
+      long expectedExpiration = entry.expectedExpiration.get();
+      if (expectedExpiration == NO_EXPIRATION)
+        return;
+
       final WeakReference<ExpiringEntry<K, V>> entryReference = new WeakReference<ExpiringEntry<K, V>>(entry);
       runnable = new Runnable() {
         @Override
@@ -1391,8 +1404,13 @@ public class ExpiringMap<K, V> implements ConcurrentMap<K, V> {
         }
       };
 
-      Future<?> entryFuture = EXPIRER.schedule(runnable, entry.expectedExpiration.get() - System.nanoTime(),
-          TimeUnit.NANOSECONDS);
+      long now = System.nanoTime();
+      long delay = expectedExpiration - now;
+      if (expectedExpiration <= now)
+        delay = 0;
+      else if (delay < 0)
+        delay = Long.MAX_VALUE;
+      Future<?> entryFuture = EXPIRER.schedule(runnable, delay, TimeUnit.NANOSECONDS);
       entry.schedule(entryFuture);
     }
   }

--- a/src/test/java/net/jodah/expiringmap/issues/Issue93.java
+++ b/src/test/java/net/jodah/expiringmap/issues/Issue93.java
@@ -1,0 +1,52 @@
+package net.jodah.expiringmap.issues;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.Test;
+
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
+
+@Test
+public class Issue93 {
+  private interface Condition {
+    boolean test();
+  }
+
+  private static void awaitTrue(Condition condition, long timeoutMillis) throws InterruptedException {
+    long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+    while (System.nanoTime() < deadline) {
+      if (condition.test())
+        return;
+      Thread.sleep(10);
+    }
+    assertTrue(condition.test(), "condition not met within " + timeoutMillis + "ms");
+  }
+
+  public void testVeryLongExpirationDoesNotBlockShortExpirations() throws Exception {
+    ExpiringMap<String, String> map = ExpiringMap.builder()
+        .variableExpiration()
+        .build();
+
+    map.put("A", "alpha", ExpirationPolicy.CREATED, Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+    map.put("B", "bravo", ExpirationPolicy.CREATED, 200, TimeUnit.MILLISECONDS);
+    map.put("C", "charlie", ExpirationPolicy.CREATED, 400, TimeUnit.MILLISECONDS);
+
+    awaitTrue(new Condition() {
+      public boolean test() {
+        return map.get("B") == null;
+      }
+    }, 2000);
+    assertEquals(map.get("A"), "alpha");
+
+    awaitTrue(new Condition() {
+      public boolean test() {
+        return map.get("C") == null;
+      }
+    }, 2000);
+    assertEquals(map.get("A"), "alpha");
+  }
+}


### PR DESCRIPTION
## Problem
Using extremely large TTLs (e.g., Long.MAX_VALUE or values that saturate to it) can break expiration scheduling. The code computes `expectedExpiration = now + duration` in nanoseconds. With a huge duration this overflows to a negative value, making that entry look like the earliest expiration. The scheduler then computes `expectedExpiration - now`, which underflows to a massive positive delay (~292 years). Because ExpiringMap schedules one entry at a time, short TTL entries stop expiring.

## Fix
- Use saturating addition when computing `expectedExpiration` to avoid overflow.
- Treat `Long.MAX_VALUE` as "no expiration" and skip scheduling such entries.
- Clamp delay when already due to avoid negative/overflow delays.

## Tests
- Added Issue93 regression test to ensure a very long TTL does not block short TTL expirations.